### PR TITLE
Fledgling but better code coverage abilities (#3)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,16 @@ os:
   - osx
 
 dist: xenial
+osx_image: xcode10.1
 
 compiler:
   - gcc
   - clang
+
+matrix:
+  exclude:
+  - compiler: gcc
+    os: osx
 
 addons:
   apt:
@@ -19,8 +25,17 @@ addons:
 
 script:
   - if [ $TRAVIS_OS_NAME = linux ]; then make test_full; fi
+  - if [ $TRAVIS_OS_NAME = linux ]; then make clean; fi
   - make -j2 coverage
 
 after_success:
-  - gcov -o build src/vm.cpp src/memory.cpp src/instruction.cpp
-  - bash <(curl -s https://codecov.io/bash) -f "*.cpp.gcov"
+  - if [ $TRAVIS_COMPILER = gcc ]; then
+      gcov -o build src/vm.cpp src/memory.cpp src/instruction.cpp;
+    fi
+  - if [ $TRAVIS_OS_NAME = linux ] && [ $TRAVIS_COMPILER = clang ]; then
+      llvm-cov gcov -o build src/vm.cpp src/memory.cpp src/instruction.cpp;
+    fi
+  - if [ $TRAVIS_OS_NAME = osx ] && [ $TRAVIS_COMPILER = clang ]; then
+      xcrun llvm-cov gcov -o build src/vm.cpp src/memory.cpp src/instruction.cpp;
+    fi
+  - bash <(curl -s https://codecov.io/bash) -f instruction.cpp.gcov -f memory.cpp.gcov -f vm.cpp.gcov -X gcov -F "${TRAVIS_OS_NAME}_${TRAVIS_COMPILER}"

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 CXX_STANDARD = c++14
 CXX_STANDARD_OPT = -std=$(CXX_STANDARD)
 CXX_OPTIMIZE_OPT = -O2
+CXX_NO_OPTIMIZE_OPT = -O0
 CXX_ERRORS_OPT = -pedantic-errors
 CXX_SUGGEST_OPT = -Wsuggest-attribute=pure -Wsuggest-attribute=const
 CXX_WARNINGS_OPT = -Wall -Wextra -Wpedantic -Wshadow
@@ -14,7 +15,6 @@ CXXFLAGS += $(CXX_OPTIMIZE_OPT)
 CXXFLAGS += $(CXX_ERRORS_OPT)
 CXXFLAGS += $(CXX_SUGGEST_OPT)
 CXXFLAGS += $(CXX_WARNINGS_OPT)
-#CXXFLAGS += $(CXX_COVERAGE_OPT)
 
 LD = ld
 
@@ -58,6 +58,7 @@ test_full: test_memcheck test_callgrind
 
 # Runs test but with gcov coverage enabled.
 coverage: CXXFLAGS += $(CXX_COVERAGE_OPT)
+coverage: CXX_OPTIMIZE_OPT = $(CXX_NO_OPTIMIZE_OPT)
 coverage: test
 
 # Deletes the build folder.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@
 Credit for the Pendulum 32-bit Instruction Set Architecture goes to Carlin James
 Vieri.
 
-Metronome32 is made by Grayson Burton.
+Metronome32 is made by Grayson Burton and is hosted at
+[its Github repo](https://github.com/ocornoc/metronome32).
 
 ## What is Pendulum?
 
@@ -41,3 +42,11 @@ It uses SD-6 feature tests to optionally enable some attributes such as
 `[[fallthrough]]`. It does not test for `[[maybe_unused]]` support, instead
 presuming the compiler doesn't actually treat it as an error if it cannot be
 used.
+
+## Routine Testing
+
+Currently, Metronome32's master branch is tested on a per pull request basis.
+It uses [Travis CI](https://travis-ci.com/) to test on:
+ * Ubuntu Xenial Xerus 16.04 LTS using GCC 5.4.0
+ * Ubuntu Xenial Xerus 16.04 LTS using Clang/LLVM 7.0
+ * macOS 10.13 (Xcode 10.1) using Clang/LLVM 9.1

--- a/src/vm.cpp
+++ b/src/vm.cpp
@@ -56,18 +56,6 @@ context_data p32::fresh_context(const instructions_t& instructions, const regist
 	return context_data(instructions, start_pc);
 }
 
-p32::vm::vm(const std::string& bytecode, register_value start_at, register_value load_at)
-	: context(start_at)
-{
-	if (not bytecode.empty()) {
-		for (const char& bc : bytecode) {
-			auto br = static_cast<decltype(context.sys_mem)::mapped_type>(bc);
-			context.sys_mem[load_at] = br;
-			load_at++;
-		}
-	}
-}
-
 p32::vm::vm(const std::vector<p32::memory_value>& bytecode, register_value start_at, register_value load_at)
 	: context(start_at)
 {

--- a/src/vm.h
+++ b/src/vm.h
@@ -154,7 +154,6 @@ class metronome32::vm {
 		vm& operator=(const vm&) = default;
 		vm& operator=(vm&&) = default;
 		~vm() = default;
-		vm(const std::string& bytecode = "", register_value start_at = 0, register_value load_at = 0);
 		vm(const std::vector<memory_value>& bytecode = {}, register_value start_at = 0, register_value load_at = 0);
 	
 	private:


### PR DESCRIPTION
* Updated copyright year

It's not 2018 anymore, apparently.

* Added another coverage test

This adds coverage tests for instruction conversions.

* Removed obsolete std::string VM constructor

There was a "legacy" std::string VM constructor back when Metronome32's
VM used byte memory instead of 4-byte memory.

* Stop counting the test file in the coverage report

* Now being specific with which reports are used

* Codecov doesn't want to behave, going to bodge

* Start using flags in codecov for OS and toolchain

* Disabled gcov exec from codecov

It kept auto-executing gcov from the Codecov bash uploader even though
we already ran it, which is unfortunate.

* Added toolchain-specific coverage support

* I don't think Codecov likes multiline stuff

* osx_clang wouldn't report as it didn't have llvm-cov

* Added info to README about Travis tests

* Makefile coverage no longer optimizes at all

* Excluded GCC on OSX and tidied Travis file

GCC on OSX is simply aliased Clang, so it serves no purpose to test it
if we already test Clang.

* Forgot end semicolons